### PR TITLE
商品一覧表示機能#6

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all
+    @items = Item.all.order("created_at DESC")
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
+    @items = Item.all
   end
 
   def new

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,7 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new]
 
   def index
-    @items = Item.all.order("created_at DESC")
+    @items = Item.all.order('created_at DESC')
   end
 
   def new

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,6 +128,8 @@
     </div>
     <ul class='item-lists'>
 
+    <%# itemsテーブルに商品があるときには以下を表示する%>
+    <% if @items.present? %>
       <%# 商品の中身を取り出すeach~do記述は<li>の上に記述する、下に記述すると取り出す要素それぞれがリストとして扱われない %>
       <% @items.each do |item| %>
       <li class='list'>
@@ -135,7 +137,7 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう 商品購入機能実装後にif文で分岐する %>
+          <%# 商品が売れていればsold outを表示しましょう 商品購入機能実装後にif文で分岐する 今は全てに表示される %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
@@ -155,12 +157,12 @@
           </div>
         </div>
         <% end %>
-        <% end %>
+      <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-      <%# 商品がない場合は以下のダミー商品が表示されるようにしましょう %>
-      <%# 商品がある場合は表示されないようにしましょう %>
+    <%# itemsテーブルに商品がない場合は以下のダミー商品を表示する %>
+    <% else %>
       <li class='list'>
         <%= link_to '#' do %>
         <%= image_tag "https://tech-master.s3.amazonaws.com/uploads/curriculums/images/Rails1-4/sample.jpg", class: "item-img" %>
@@ -178,8 +180,7 @@
         </div>
         <% end %>
       </li>
-      <%# //商品がある場合は表示されないようにしましょう %>
-      <%# //商品がない場合は以下のダミー商品が表示されるようにしましょう %>
+    <% end %>
     </ul>
   </div>
   <%# /商品一覧 %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -137,8 +137,8 @@
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう 商品購入機能実装後にif文で分岐する 今は全てに表示される %>
-          <div class='sold-out'>
+          <%# 商品が売れていればsold outを表示しましょう 商品購入機能実装後にif文で分岐する 今は全てに表示される/コメントアウトで非表示中 %>
+          <%#div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
           <%# //商品が売れていればsold outを表示しましょう %>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -149,7 +149,7 @@
             <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= item.price %>円<br><%= item.shipping_charges_id %></span>
+            <span><%= item.price %>円<br><%= item.shipping_charges.name %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -128,13 +128,14 @@
     </div>
     <ul class='item-lists'>
 
-      <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
+      <%# 商品の中身を取り出すeach~do記述は<li>の上に記述する、下に記述すると取り出す要素それぞれがリストとして扱われない %>
+      <% @items.each do |item| %>
       <li class='list'>
         <%= link_to "#" do %>
         <div class='item-img-content'>
-          <%= image_tag "item-sample.png", class: "item-img" %>
+          <%= image_tag item.image, class: "item-img" %>
 
-          <%# 商品が売れていればsold outを表示しましょう %>
+          <%# 商品が売れていればsold outを表示しましょう 商品購入機能実装後にif文で分岐する %>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
@@ -143,16 +144,17 @@
         </div>
         <div class='item-info'>
           <h3 class='item-name'>
-            <%= "商品名" %>
+            <%= item.item_name %>
           </h3>
           <div class='item-price'>
-            <span><%= "販売価格" %>円<br><%= '配送料負担' %></span>
+            <span><%= item.price %>円<br><%= item.shipping_charges_id %></span>
             <div class='star-btn'>
               <%= image_tag "star.png", class:"star-icon" %>
               <span class='star-count'>0</span>
             </div>
           </div>
         </div>
+        <% end %>
         <% end %>
       </li>
       <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>


### PR DESCRIPTION
# What
商品一覧表示機能

# Why
フリマアプリのため、出品した商品をuserが一覧で見ることができるようにする必要がある

# プルリクエストへ記載するgyazo
・商品のデータがない場合は、ダミー商品が表示されている動画
https://i.gyazo.com/a04b0abbd8af3491bb4bb37d7e9a7a37.gif
・商品のデータがある場合は、商品が一覧で表示されている動画
https://i.gyazo.com/5782f0d4083182a40d917f091fc9333a.gif

今回商品購入機能の実装はまだのため、soldout表示は全て表示される状態です。そのためコメントアウトで非表示にしています。